### PR TITLE
Add the Python dependency

### DIFF
--- a/scripts/gvisor.sh
+++ b/scripts/gvisor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-sudo apt-get install -y git
+sudo apt-get install -y git python
 
 git clone https://gvisor.googlesource.com/gvisor gvisor
 


### PR DESCRIPTION
Hi Takaaki,

Thank you very much for your project which helped me a lot in quickly setting up an environment to try gVisor on a mac. I just found a small issue that I send this PR to fix. gVisor now also depends on Python for installation. Without it, we would run into the following error with `vagrant up`:

```console
...
    default: + bazel build runsc
...
    default: ERROR: /home/vagrant/gvisor/vdso/BUILD:20:1: Executing genrule //vdso:vdso failed (Exit 127) bash failed: error executing command /bin/bash -c ... (remaining 1 argument(s) skipped)
...
    default: /usr/bin/env: 'python': No such file or directory
...
```